### PR TITLE
Update MerchantGuide.md

### DIFF
--- a/MerchantGuide.md
+++ b/MerchantGuide.md
@@ -80,3 +80,5 @@ Done by calling
 where the amount is in Satoshi.
 
 When calling this function the merchant WBTC will be burned, and the custodian will later send equivalent amount of BTC (minus applicable fees) to the merchant BTC deposit address (that was set in the initial setup).
+
+***DO NOT call `burn` in WBTC token contract, you will lose your wbtc forever***


### PR DESCRIPTION
**Problem:**

Factory contract and wbtc token contract both have `burn` function to call. Even though at the beginning of the guide we clearly say "All the function call we describe in this guide are done to the factory smart contract", I still find it pretty easy to make mistake if someone missed that line and just go ahead with whatever `burn` they see first.

**Proposal:**

I proposed to put an extra note at the end of burning section to stop them from calling burn in the token contract.